### PR TITLE
Fixes to make Scrutinizer run correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,15 +237,16 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is-terminal",
  "utf8parse",
 ]
 
@@ -275,12 +276,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -986,33 +987,35 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
 dependencies = [
  "clap_builder",
  "clap_derive",
+ "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
 dependencies = [
  "anstream",
  "anstyle",
+ "bitflags 1.3.2",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim 0.10.0",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.60",
@@ -1020,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "cmake"
@@ -1637,12 +1640,13 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.0"
+version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
 dependencies = [
  "futures-core",
  "futures-sink",
+ "pin-project",
  "spin 0.9.8",
 ]
 
@@ -2047,12 +2051,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2172,7 +2170,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2598,9 +2596,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.27.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3319,7 +3317,7 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec4c6225c69b4ca778c0aea097321a64c421cf4577b331c61b229267edabb6f8"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -3658,6 +3656,7 @@ name = "portfolio-api"
 version = "2.0.0"
 dependencies = [
  "alohomora",
+ "alohomora_build",
  "alohomora_derive",
  "async-trait",
  "chrono",
@@ -4563,7 +4562,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bd3534a9978d0aa7edd2808dc1f8f31c4d0ecd31ddf71d997b3c98e9f3c9114"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -4603,7 +4602,7 @@ version = "0.12.15"
 source = "git+https://github.com/KinanBab/sea-orm.git?branch=main#883864421bbd14c24ea776835d5f57745b143bf9"
 dependencies = [
  "chrono",
- "clap 4.5.4",
+ "clap 4.3.0",
  "dotenvy",
  "glob",
  "regex",
@@ -4618,7 +4617,7 @@ name = "sea-orm-macros"
 version = "0.12.15"
 source = "git+https://github.com/KinanBab/sea-orm.git?branch=main#883864421bbd14c24ea776835d5f57745b143bf9"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "sea-bae",
@@ -4632,7 +4631,7 @@ version = "0.12.15"
 source = "git+https://github.com/KinanBab/sea-orm.git?branch=main#883864421bbd14c24ea776835d5f57745b143bf9"
 dependencies = [
  "async-trait",
- "clap 4.5.4",
+ "clap 4.3.0",
  "dotenvy",
  "futures",
  "sea-orm",
@@ -4700,7 +4699,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a82fcb49253abcb45cdcb2adf92956060ec0928635eb21b4f7a6d8f25ab0bc"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.60",
@@ -4724,7 +4723,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f686050f76bffc4f635cda8aea6df5548666b830b52387e8bc7de11056d11e"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -4800,18 +4799,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5127,9 +5126,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.7.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
+checksum = "91ef53c86d2066e04f0ac6b1364f16d13d82388e2d07f11a5c71782345555761"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -5140,9 +5139,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.7.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
+checksum = "8a22fd81e9c1ad53c562edb869ff042b215d4eadefefc4784bacfbfd19835945"
 dependencies = [
  "ahash 0.8.11",
  "atoi",
@@ -5152,6 +5151,7 @@ dependencies = [
  "chrono",
  "crc",
  "crossbeam-queue",
+ "dotenvy",
  "either",
  "event-listener",
  "futures-channel",
@@ -5185,9 +5185,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.7.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
+checksum = "00bb7c096a202b8164c175614cbfb79fe0e1e0a3d50e0374526183ef2974e4a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5198,13 +5198,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.7.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
+checksum = "37d644623ab9699014e5b3cb61a040d16caa50fd477008f63f1399ae35498a58"
 dependencies = [
  "dotenvy",
  "either",
- "heck 0.4.1",
+ "heck",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -5224,9 +5224,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.7.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
+checksum = "8264c59b28b6858796acfcedc660aa4c9075cc6e4ec8eb03cdca2a3e725726db"
 dependencies = [
  "atoi",
  "base64 0.21.7",
@@ -5271,9 +5271,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.7.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
+checksum = "1cab6147b81ca9213a7578f1b4c9d24c449a53953cd2222a7b5d7cd29a5c3139"
 dependencies = [
  "atoi",
  "base64 0.21.7",
@@ -5302,6 +5302,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
+ "sha1 0.10.6",
  "sha2 0.10.8",
  "smallvec",
  "sqlx-core",
@@ -5315,9 +5316,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.7.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
+checksum = "59fba60afa64718104b71eec6984f8779d4caffff3b30cde91a75843c7efc126"
 dependencies = [
  "atoi",
  "chrono",
@@ -5335,7 +5336,6 @@ dependencies = [
  "time 0.3.36",
  "tracing",
  "url",
- "urlencoding",
  "uuid 1.8.0",
 ]
 
@@ -5443,12 +5443,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -5966,8 +5960,8 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
- "rand 0.8.5",
+ "cfg-if 0.1.10",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
@@ -6170,12 +6164,6 @@ dependencies = [
  "idna 0.5.0",
  "percent-encoding",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [workspace]
-#members = [".", "api", "core", "entity", "migration", "cli", "policies"]
+# members = [".", "api", "core", "entity", "migration", "cli", "policies"]
 members = [".", "api", "core", "entity", "migration", "policies", "harness"]
 
 [dependencies]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -45,6 +45,8 @@ features = [ "sqlx-mysql", "sqlx-sqlite", "runtime-tokio-native-tls" ]
 git = "https://github.com/KinanBab/sea-orm.git"
 branch = "main"
 
-
 [dev-dependencies]
 portfolio-core = { path = "../core" }
+
+[build-dependencies]
+alohomora_build = { path = "../../alohomora/alohomora_build" }

--- a/api/build.rs
+++ b/api/build.rs
@@ -2,5 +2,5 @@ extern crate alohomora_build;
 use alohomora_build::alohomora_build;
 
 fn main() {
-    alohomora_build(true, &["../sandbox"]);
+    alohomora_build(true, &[]);
 }

--- a/api/scrutinizer-config.toml
+++ b/api/scrutinizer-config.toml
@@ -1,0 +1,224 @@
+mode = "ppr"
+only_inconsistent = false
+output_file = "scrutinizer.result.json"
+
+# We only want the first argument to the closure to be treated as important
+# Since arguments are 1-indexed and the very first one is the closure itself, we mark arg#2 as important.
+important_args = [2]
+allowlist = [
+  # Prefetching.
+  'core\[\w*\]::intrinsics::\{extern#0\}::prefetch_read_data',
+  'core\[\w*\]::intrinsics::\{extern#0\}::prefetch_write_data',
+  'core\[\w*\]::intrinsics::\{extern#0\}::prefetch_read_instruction',
+  'core\[\w*\]::intrinsics::\{extern#0\}::prefetch_write_instruction',
+
+  # Optimizer.
+  'core\[\w*\]::intrinsics::\{extern#0\}::likely',
+  'core\[\w*\]::intrinsics::\{extern#0\}::unlikely',
+  'core\[\w*\]::intrinsics::\{extern#0\}::unreachable',
+  'core\[\w*\]::intrinsics::\{extern#0\}::assume',
+  'core\[\w*\]::intrinsics::\{extern#0\}::black_box',
+
+  # Breakpoint.
+  'core\[\w*\]::intrinsics::\{extern#0\}::breakpoint',
+
+  # size_of and others.
+  'core\[\w*\]::intrinsics::\{extern#0\}::size_of',
+  'core\[\w*\]::intrinsics::\{extern#0\}::min_align_of',
+  'core\[\w*\]::intrinsics::\{extern#0\}::pref_align_of',
+  'core\[\w*\]::intrinsics::\{extern#0\}::size_of_val',
+  'core\[\w*\]::intrinsics::\{extern#0\}::min_align_of_val',
+
+  # Assertions.
+  'core\[\w*\]::intrinsics::\{extern#0\}::assert_inhabited',
+  'core\[\w*\]::intrinsics::\{extern#0\}::assert_zero_valid',
+  'core\[\w*\]::intrinsics::\{extern#0\}::assert_mem_uninitialized_valid',
+
+  # Needs drop.
+  'core\[\w*\]::intrinsics::\{extern#0\}::needs_drop',
+
+  # Offsets.
+  'core\[\w*\]::intrinsics::\{extern#0\}::arith_offset',
+  'core\[\w*\]::intrinsics::\{extern#0\}::offset',
+
+  # Ptr mask.
+  'core\[\w*\]::intrinsics::\{extern#0\}::ptr_mask',
+
+  # Number operations.
+  'core\[\w*\]::intrinsics::\{extern#0\}::sqrtf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::sqrtf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::powif32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::powif64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::sinf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::sinf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::cosf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::cosf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::powf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::powf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::expf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::expf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::exp2f32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::exp2f64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::logf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::logf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::log10f32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::log10f64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::log2f32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::log2f64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::fmaf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::fmaf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::fabsf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::fabsf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::minnumf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::minnumf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::maxnumf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::maxnumf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::copysignf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::copysignf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::floorf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::floorf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::ceilf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::ceilf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::truncf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::truncf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::rintf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::rintf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::nearbyintf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::nearbyintf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::roundf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::roundf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::roundevenf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::roundevenf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::fadd_fast',
+  'core\[\w*\]::intrinsics::\{extern#0\}::fsub_fast',
+  'core\[\w*\]::intrinsics::\{extern#0\}::fmul_fast',
+  'core\[\w*\]::intrinsics::\{extern#0\}::fdiv_fast',
+  'core\[\w*\]::intrinsics::\{extern#0\}::frem_fast',
+  'core\[\w*\]::intrinsics::\{extern#0\}::float_to_int_unchecked',
+
+  # Bit operations
+  'core\[\w*\]::intrinsics::\{extern#0\}::ctpop',
+  'core\[\w*\]::intrinsics::\{extern#0\}::ctlz',
+  'core\[\w*\]::intrinsics::\{extern#0\}::ctlz_nonzero',
+  'core\[\w*\]::intrinsics::\{extern#0\}::cttz',
+  'core\[\w*\]::intrinsics::\{extern#0\}::cttz_nonzero',
+  'core\[\w*\]::intrinsics::\{extern#0\}::bswap',
+  'core\[\w*\]::intrinsics::\{extern#0\}::bitreverse',
+
+  # Arithmetic operations with overflow.
+  'core\[\w*\]::intrinsics::\{extern#0\}::add_with_overflow',
+  'core\[\w*\]::intrinsics::\{extern#0\}::sub_with_overflow',
+  'core\[\w*\]::intrinsics::\{extern#0\}::mul_with_overflow',
+
+  # Rotates.
+  'core\[\w*\]::intrinsics::\{extern#0\}::rotate_left',
+  'core\[\w*\]::intrinsics::\{extern#0\}::rotate_right',
+
+  # Wrapping arithmetic operations.
+  'core\[\w*\]::intrinsics::\{extern#0\}::wrapping_add',
+  'core\[\w*\]::intrinsics::\{extern#0\}::wrapping_sub',
+  'core\[\w*\]::intrinsics::\{extern#0\}::wrapping_mul',
+
+  # Saturating arithmetic operations.
+  'core\[\w*\]::intrinsics::\{extern#0\}::saturating_add',
+  'core\[\w*\]::intrinsics::\{extern#0\}::saturating_sub',
+
+  # Read arbitrary memory.
+  'core\[\w*\]::intrinsics::\{extern#0\}::read_via_copy',
+
+  # Discriminants.
+  'core\[\w*\]::intrinsics::\{extern#0\}::discriminant_value',
+
+  # Variants.
+  'core\[\w*\]::intrinsics::\{extern#0\}::variant_count',
+
+  # const* business.
+  'core\[\w*\]::intrinsics::\{extern#0\}::ptr_offset_from',
+  'core\[\w*\]::intrinsics::\{extern#0\}::ptr_offset_from_unsigned',
+  'core\[\w*\]::intrinsics::\{extern#0\}::ptr_guaranteed_cmp',
+
+  # Constant evaluation.
+  'core\[\w*\]::intrinsics::\{extern#0\}::const_allocate',
+  'core\[\w*\]::intrinsics::\{extern#0\}::const_deallocate',
+  'core\[\w*\]::intrinsics::\{extern#0\}::const_eval_select',
+
+  # Raw equality comparison.
+  'core\[\w*\]::intrinsics::\{extern#0\}::raw_eq',
+  'core\[\w*\]::intrinsics::\{extern#0\}::compare_bytes',
+
+  # Vtable.
+  'core\[\w*\]::intrinsics::\{extern#0\}::vtable_size',
+  'core\[\w*\]::intrinsics::\{extern#0\}::vtable_align',
+
+  # Unchecked arithmetic operations.
+  'core\[\w*\]::intrinsics::\{extern#0\}::exact_div',
+  'core\[\w*\]::intrinsics::\{extern#0\}::unchecked_add',
+  'core\[\w*\]::intrinsics::\{extern#0\}::unchecked_div',
+  'core\[\w*\]::intrinsics::\{extern#0\}::unchecked_mul',
+  'core\[\w*\]::intrinsics::\{extern#0\}::unchecked_rem',
+  'core\[\w*\]::intrinsics::\{extern#0\}::unchecked_shl',
+  'core\[\w*\]::intrinsics::\{extern#0\}::unchecked_shr',
+  'core\[\w*\]::intrinsics::\{extern#0\}::unchecked_sub',  
+
+  # Dynamic typing.
+  'core\[\w*\]::intrinsics::\{extern#0\}::type_id',
+  'core\[\w*\]::intrinsics::\{extern#0\}::type_name',
+
+  # Transmute is allowlisted as an intrinsic, but is checked for separately.
+  'core\[\w*\]::intrinsics::\{extern#0\}::transmute',
+
+  # Panicking infrastructure.
+  'core\[\w*\]::panicking::assert_failed',
+  'core\[\w*\]::panicking::const_panic_fmt',
+  'core\[\w*\]::panicking::panic',
+  'core\[\w*\]::panicking::panic_display',
+  'core\[\w*\]::panicking::panic_fmt',
+  'core\[\w*\]::panicking::panic_nounwind',
+  'core\[\w*\]::panicking::panic_nounwind_fmt',
+  'core\[\w*\]::panicking::panic_str',
+  'core\[\w*\]::panicking::unreachable_display',
+
+  # Alloc infrastructure.
+  'alloc\[\w*\]::alloc::alloc',
+  'alloc\[\w*\]::alloc::alloc_zeroed',
+  'alloc\[\w*\]::alloc::dealloc',
+  'alloc\[\w*\]::alloc::realloc',
+  # Impls of global allocator.
+  'alloc\[\w*\]::alloc::\{impl#0\}',
+  'alloc\[\w*\]::alloc::\{impl#1\}',
+
+  # Format chrono.
+  'chrono\[\w*\]::naive::datetime::\{impl#0\}::format',
+  'alloc\[\w*\]::string::\{impl#41\}::to_string',
+  'core\[\w*\]::fmt::\{impl#3\}::new',
+
+  # Format strings.
+  'alloc\[\w*\]::fmt::format',
+
+  # Rust 1.70 calls to memcmp to compare slices.
+  # This is removed in further versions.
+  'core\[\w*\]::slice::cmp::\{extern#0\}::memcmp',
+
+  # Architecture-dependent intrinsics.
+  'core\[\w*\]::core_arch',
+
+  # Pointer-address conversion primitives.
+  'core\[\w*\]::ptr::invalid',
+  'core\[\w*\]::ptr::invalid_mut',
+  'core\[\w*\]::ptr::const_ptr::\{impl#0\}::addr',
+  'core\[\w*\]::ptr::mut_ptr::\{impl#0\}::addr',
+  'core\[\w*\]::ptr::alignment::\{impl#0\}::new_unchecked',
+]
+trusted_stdlib = [
+  # Vec collection.
+  'alloc\[\w*\]::vec',
+  # Slice.
+  'alloc\[\w*\]::slice',
+  'core\[\w*\]::slice',
+  # String.
+  'alloc\[\w*\]::string',
+  # Hashmap.
+  'std\[\w*\]::collections::hash::map',
+  # Btreemap.
+  'alloc\[\w*\]::collections::btree'
+]

--- a/core/scrutinizer-config.toml
+++ b/core/scrutinizer-config.toml
@@ -1,0 +1,224 @@
+mode = "ppr"
+only_inconsistent = false
+output_file = "scrutinizer.result.json"
+
+# We only want the first argument to the closure to be treated as important
+# Since arguments are 1-indexed and the very first one is the closure itself, we mark arg#2 as important.
+important_args = [2]
+allowlist = [
+  # Prefetching.
+  'core\[\w*\]::intrinsics::\{extern#0\}::prefetch_read_data',
+  'core\[\w*\]::intrinsics::\{extern#0\}::prefetch_write_data',
+  'core\[\w*\]::intrinsics::\{extern#0\}::prefetch_read_instruction',
+  'core\[\w*\]::intrinsics::\{extern#0\}::prefetch_write_instruction',
+
+  # Optimizer.
+  'core\[\w*\]::intrinsics::\{extern#0\}::likely',
+  'core\[\w*\]::intrinsics::\{extern#0\}::unlikely',
+  'core\[\w*\]::intrinsics::\{extern#0\}::unreachable',
+  'core\[\w*\]::intrinsics::\{extern#0\}::assume',
+  'core\[\w*\]::intrinsics::\{extern#0\}::black_box',
+
+  # Breakpoint.
+  'core\[\w*\]::intrinsics::\{extern#0\}::breakpoint',
+
+  # size_of and others.
+  'core\[\w*\]::intrinsics::\{extern#0\}::size_of',
+  'core\[\w*\]::intrinsics::\{extern#0\}::min_align_of',
+  'core\[\w*\]::intrinsics::\{extern#0\}::pref_align_of',
+  'core\[\w*\]::intrinsics::\{extern#0\}::size_of_val',
+  'core\[\w*\]::intrinsics::\{extern#0\}::min_align_of_val',
+
+  # Assertions.
+  'core\[\w*\]::intrinsics::\{extern#0\}::assert_inhabited',
+  'core\[\w*\]::intrinsics::\{extern#0\}::assert_zero_valid',
+  'core\[\w*\]::intrinsics::\{extern#0\}::assert_mem_uninitialized_valid',
+
+  # Needs drop.
+  'core\[\w*\]::intrinsics::\{extern#0\}::needs_drop',
+
+  # Offsets.
+  'core\[\w*\]::intrinsics::\{extern#0\}::arith_offset',
+  'core\[\w*\]::intrinsics::\{extern#0\}::offset',
+
+  # Ptr mask.
+  'core\[\w*\]::intrinsics::\{extern#0\}::ptr_mask',
+
+  # Number operations.
+  'core\[\w*\]::intrinsics::\{extern#0\}::sqrtf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::sqrtf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::powif32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::powif64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::sinf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::sinf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::cosf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::cosf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::powf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::powf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::expf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::expf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::exp2f32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::exp2f64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::logf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::logf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::log10f32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::log10f64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::log2f32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::log2f64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::fmaf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::fmaf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::fabsf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::fabsf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::minnumf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::minnumf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::maxnumf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::maxnumf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::copysignf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::copysignf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::floorf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::floorf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::ceilf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::ceilf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::truncf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::truncf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::rintf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::rintf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::nearbyintf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::nearbyintf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::roundf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::roundf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::roundevenf32',
+  'core\[\w*\]::intrinsics::\{extern#0\}::roundevenf64',
+  'core\[\w*\]::intrinsics::\{extern#0\}::fadd_fast',
+  'core\[\w*\]::intrinsics::\{extern#0\}::fsub_fast',
+  'core\[\w*\]::intrinsics::\{extern#0\}::fmul_fast',
+  'core\[\w*\]::intrinsics::\{extern#0\}::fdiv_fast',
+  'core\[\w*\]::intrinsics::\{extern#0\}::frem_fast',
+  'core\[\w*\]::intrinsics::\{extern#0\}::float_to_int_unchecked',
+
+  # Bit operations
+  'core\[\w*\]::intrinsics::\{extern#0\}::ctpop',
+  'core\[\w*\]::intrinsics::\{extern#0\}::ctlz',
+  'core\[\w*\]::intrinsics::\{extern#0\}::ctlz_nonzero',
+  'core\[\w*\]::intrinsics::\{extern#0\}::cttz',
+  'core\[\w*\]::intrinsics::\{extern#0\}::cttz_nonzero',
+  'core\[\w*\]::intrinsics::\{extern#0\}::bswap',
+  'core\[\w*\]::intrinsics::\{extern#0\}::bitreverse',
+
+  # Arithmetic operations with overflow.
+  'core\[\w*\]::intrinsics::\{extern#0\}::add_with_overflow',
+  'core\[\w*\]::intrinsics::\{extern#0\}::sub_with_overflow',
+  'core\[\w*\]::intrinsics::\{extern#0\}::mul_with_overflow',
+
+  # Rotates.
+  'core\[\w*\]::intrinsics::\{extern#0\}::rotate_left',
+  'core\[\w*\]::intrinsics::\{extern#0\}::rotate_right',
+
+  # Wrapping arithmetic operations.
+  'core\[\w*\]::intrinsics::\{extern#0\}::wrapping_add',
+  'core\[\w*\]::intrinsics::\{extern#0\}::wrapping_sub',
+  'core\[\w*\]::intrinsics::\{extern#0\}::wrapping_mul',
+
+  # Saturating arithmetic operations.
+  'core\[\w*\]::intrinsics::\{extern#0\}::saturating_add',
+  'core\[\w*\]::intrinsics::\{extern#0\}::saturating_sub',
+
+  # Read arbitrary memory.
+  'core\[\w*\]::intrinsics::\{extern#0\}::read_via_copy',
+
+  # Discriminants.
+  'core\[\w*\]::intrinsics::\{extern#0\}::discriminant_value',
+
+  # Variants.
+  'core\[\w*\]::intrinsics::\{extern#0\}::variant_count',
+
+  # const* business.
+  'core\[\w*\]::intrinsics::\{extern#0\}::ptr_offset_from',
+  'core\[\w*\]::intrinsics::\{extern#0\}::ptr_offset_from_unsigned',
+  'core\[\w*\]::intrinsics::\{extern#0\}::ptr_guaranteed_cmp',
+
+  # Constant evaluation.
+  'core\[\w*\]::intrinsics::\{extern#0\}::const_allocate',
+  'core\[\w*\]::intrinsics::\{extern#0\}::const_deallocate',
+  'core\[\w*\]::intrinsics::\{extern#0\}::const_eval_select',
+
+  # Raw equality comparison.
+  'core\[\w*\]::intrinsics::\{extern#0\}::raw_eq',
+  'core\[\w*\]::intrinsics::\{extern#0\}::compare_bytes',
+
+  # Vtable.
+  'core\[\w*\]::intrinsics::\{extern#0\}::vtable_size',
+  'core\[\w*\]::intrinsics::\{extern#0\}::vtable_align',
+
+  # Unchecked arithmetic operations.
+  'core\[\w*\]::intrinsics::\{extern#0\}::exact_div',
+  'core\[\w*\]::intrinsics::\{extern#0\}::unchecked_add',
+  'core\[\w*\]::intrinsics::\{extern#0\}::unchecked_div',
+  'core\[\w*\]::intrinsics::\{extern#0\}::unchecked_mul',
+  'core\[\w*\]::intrinsics::\{extern#0\}::unchecked_rem',
+  'core\[\w*\]::intrinsics::\{extern#0\}::unchecked_shl',
+  'core\[\w*\]::intrinsics::\{extern#0\}::unchecked_shr',
+  'core\[\w*\]::intrinsics::\{extern#0\}::unchecked_sub',  
+
+  # Dynamic typing.
+  'core\[\w*\]::intrinsics::\{extern#0\}::type_id',
+  'core\[\w*\]::intrinsics::\{extern#0\}::type_name',
+
+  # Transmute is allowlisted as an intrinsic, but is checked for separately.
+  'core\[\w*\]::intrinsics::\{extern#0\}::transmute',
+
+  # Panicking infrastructure.
+  'core\[\w*\]::panicking::assert_failed',
+  'core\[\w*\]::panicking::const_panic_fmt',
+  'core\[\w*\]::panicking::panic',
+  'core\[\w*\]::panicking::panic_display',
+  'core\[\w*\]::panicking::panic_fmt',
+  'core\[\w*\]::panicking::panic_nounwind',
+  'core\[\w*\]::panicking::panic_nounwind_fmt',
+  'core\[\w*\]::panicking::panic_str',
+  'core\[\w*\]::panicking::unreachable_display',
+
+  # Alloc infrastructure.
+  'alloc\[\w*\]::alloc::alloc',
+  'alloc\[\w*\]::alloc::alloc_zeroed',
+  'alloc\[\w*\]::alloc::dealloc',
+  'alloc\[\w*\]::alloc::realloc',
+  # Impls of global allocator.
+  'alloc\[\w*\]::alloc::\{impl#0\}',
+  'alloc\[\w*\]::alloc::\{impl#1\}',
+
+  # Format chrono.
+  'chrono\[\w*\]::naive::datetime::\{impl#0\}::format',
+  'alloc\[\w*\]::string::\{impl#41\}::to_string',
+  'core\[\w*\]::fmt::\{impl#3\}::new',
+
+  # Format strings.
+  'alloc\[\w*\]::fmt::format',
+
+  # Rust 1.70 calls to memcmp to compare slices.
+  # This is removed in further versions.
+  'core\[\w*\]::slice::cmp::\{extern#0\}::memcmp',
+
+  # Architecture-dependent intrinsics.
+  'core\[\w*\]::core_arch',
+
+  # Pointer-address conversion primitives.
+  'core\[\w*\]::ptr::invalid',
+  'core\[\w*\]::ptr::invalid_mut',
+  'core\[\w*\]::ptr::const_ptr::\{impl#0\}::addr',
+  'core\[\w*\]::ptr::mut_ptr::\{impl#0\}::addr',
+  'core\[\w*\]::ptr::alignment::\{impl#0\}::new_unchecked',
+]
+trusted_stdlib = [
+  # Vec collection.
+  'alloc\[\w*\]::vec',
+  # Slice.
+  'alloc\[\w*\]::slice',
+  'core\[\w*\]::slice',
+  # String.
+  'alloc\[\w*\]::string',
+  # Hashmap.
+  'std\[\w*\]::collections::hash::map',
+  # Btreemap.
+  'alloc\[\w*\]::collections::btree'
+]


### PR DESCRIPTION
- `Cargo.lock` for multiple crates has been updated to feature versions that are compatible with the new compiler version.
- Scrutinizer configuration has been updated to include the changes to the allowlist.